### PR TITLE
Remove cinemachine from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.0.2",
-    "com.unity.cloud.gltfast": "5.2.0",
-	"com.unity.cinemachine": "2.6.17"
+    "com.unity.cloud.gltfast": "5.2.0"
   },
   "documentationUrl": "https://docs.avaturn.me/docs/integration/unity/unity_tutorial/",
   "author": {


### PR DESCRIPTION
The Cinemachine is just needed for the samples only, so we shouldn't import it in the package itself